### PR TITLE
cache potions after bank built

### DIFF
--- a/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
+++ b/src/main/java/com/banktaglayouts/BankTagLayoutsPlugin.java
@@ -309,7 +309,7 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 				bankSearch.layoutBank();
 			}
 		});
-		potionStorage.cachePotions = true;
+
 		potionStorage.setOnPotionStorageUpdated(() -> applyCustomBankTagItemPositions(false));
 	}
 
@@ -671,6 +671,9 @@ public class BankTagLayoutsPlugin extends Plugin implements MouseListener
 		if (layout == null) {
 			return;
 		}
+
+		// Trigger potion storage caching after the bank has been built
+		potionStorage.cachePotions = true;
 
 		int maxIndex = layout.getAllUsedIndexes().stream().max(Integer::compare).orElse(0);
 		int height = getYForIndex(maxIndex) + BANK_ITEM_HEIGHT;


### PR DESCRIPTION
Fix potion caching so that it runs after the bank has been built, rather than when the plugin is started. Having it run later means that potion storage does not have to be opened at all
